### PR TITLE
Add empty call to allow csharp protoc to generate a valid proxy

### DIFF
--- a/api/api.proto
+++ b/api/api.proto
@@ -419,7 +419,8 @@ message BlockReference {
 
 // the api of tron's network such as node list.
 service Network {
-
+	rpc ToDo (EmptyMessage) returns (EmptyMessage) {
+	}
 };
 
 message WitnessList {


### PR DESCRIPTION
I'm working on a .NET version of the protocol, sadly the class generator for C# will create a class that won't compile, so in order to continue working, is it possible to add a dummy empty call?
This is what I get from the protoc compiler now:

![issue](https://user-images.githubusercontent.com/3247183/41040245-209313c6-699c-11e8-88af-fbee1334f044.png)

This is my expected result

![fix](https://user-images.githubusercontent.com/3247183/41040253-2838a726-699c-11e8-811c-500b44c44f24.png)


If not possible, can you update the .proto definitions with actual calls of the proxy in the proto file?